### PR TITLE
harden: sanitize child_process call in converter.js...

### DIFF
--- a/Plugins/converter.js
+++ b/Plugins/converter.js
@@ -1,7 +1,7 @@
 import { getRandom } from "../System/Function.js";
 import { webp2mp4File } from "../System/Uploader.js";
 import { toAudio } from "../System/File-Converter.js";
-import { exec } from "child_process";
+import { execFile } from "child_process";
 import fs from "fs";
 import ffmpegPath from "ffmpeg-static";
 import PDFDocument from "pdfkit";
@@ -53,7 +53,7 @@ export default {
         await doReact("🎴");
         let mediaMess = await Atlas.downloadAndSaveMediaMessage(quoted);
         let ran = await getRandom(".png");
-        exec(`"${ffmpegPath}" -i ${mediaMess} ${ran}`, (err) => {
+        execFile(ffmpegPath, ["-i", mediaMess, ran], (err) => {
           fs.unlinkSync(mediaMess);
           if (err) {
             Atlas.sendMessage(


### PR DESCRIPTION
## Summary
Harden input handling in `Plugins/converter.js` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | javascript.lang.security.detect-child-process.detect-child-process |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `javascript.lang.security.detect-child-process.detect-child-process` |
| **File** | `Plugins/converter.js:56` |
| **Assessment** | Defensive hardening |

**Description**: Detected calls to child_process from a function argument `Atlas`. This could lead to a command injection if the input is user controllable. Try to avoid calls to child_process, and if it is needed ensure user input is correctly sanitized or sandboxed. 

## Threat Model Context

This is a web service - vulnerabilities in request handlers are directly exploitable by remote attackers.

## Changes
- `Plugins/converter.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
